### PR TITLE
add comstrek/air

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A curated collection of `live-reloading` tools and libraries associated with dif
   - [**boot-reload**](https://github.com/adzerk-oss/boot-reload)
 
 ## Go
+  - [**Air**](https://github.com/cosmtrek/air)
   - [**Gin**](https://github.com/codegangsta/gin)
     - [Readme](https://github.com/codegangsta/gin/blob/master/README.md)
   - [**Realize**](https://github.com/oxequa/realize)


### PR DESCRIPTION
no doc, since it's super straightforward (just need to modify air.toml based on project's build command)